### PR TITLE
v0.0.8 adding RST303, RST304 for unknown directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
  - echo "Checking our own docstrings are valid RST"
  - flake8 --select RST flake8_rst_docstrings.py
  - echo "Checking we can parse our valid test cases"
- - flake8 --select RST tests/test_cases/*.py
+ - flake8 --select RST --ignore RST303,RST304 tests/test_cases/*.py
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,8 @@ Code   Description
 ------ -----------------------------------------------------------------------
 RST301 Unexpected indentation.
 RST302 Malformed table.
+RST303 Unknown directive type "XXX".
+RST304 Unknown interpreted text role "XXX".
 RST399 Previously unseen major error, not yet assigned a unique code.
 ====== =======================================================================
 
@@ -167,6 +169,8 @@ v0.0.6  2017-08-18 - Support PEP263 style encodings following a hashbang line
 v0.0.7  2017-08-25 - Remove triple-quotes before linting, was causing false
                      positives reporting RST entries ending without a blank
                      line at end of docstrings (bug fix for issue #1).
+v0.0.8  2017-10-09 - Adds ``RST303`` and ``RST304`` for unknown directives and
+                     interpreted text role as used in Sphinx-Needs extension.
 ======= ========== ===========================================================
 
 

--- a/tests/test_cases/sphinx-needs.py
+++ b/tests/test_cases/sphinx-needs.py
@@ -1,0 +1,37 @@
+"""Example reStructuredText from Sphinx-Needs project.
+
+From http://sphinxcontrib-needs.readthedocs.io/en/latest/
+
+**Some data**
+
+.. req:: My first requirement
+   :id: req_001
+   :tags: example
+
+   This is an awesome requirement and it includes a nice title,
+   a given id, a tag and this text as description.
+
+.. spec:: Spec for a requirement
+   :links: req_001
+   :status: done
+   :tags: important; example
+
+   We haven't set an **ID** here, so sphinxcontrib-needs
+   will generated one for us.
+
+   But we have **set a link** to our first requirement and
+   also a *status* is given.
+
+**Some text**
+
+Wohooo, we have created :need:`req_001`,
+which is linked by :need_incoming:`req_001`.
+
+**A filter**
+
+.. needfilter::
+   :tags: example
+   :layout: table
+"""
+
+print("sphinx-needs defines its own reStructuredText directives.")


### PR DESCRIPTION
This should close #4.

I noted some odd behaviour trying to use ``# noqa`` on the docstring which seems to be a wider issue for the plugin as a whole. i.e. I wanted to have the new ``tests/test_cases/sphinx-needs.py`` example's docstring end with ``"""  # noqa: RST303,RST304`` so that my minimal TravisCI setup can expect no RST errors at all.