### PR TITLE
Add codes and README doc for 212, 305, 306

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,9 @@ v0.0.7  2017-08-25 - Remove triple-quotes before linting, was causing false
                      line at end of docstrings (bug fix for issue #1).
 v0.0.8  2017-10-09 - Adds ``RST303`` and ``RST304`` for unknown directives and
                      interpreted text role as used in Sphinx-Needs extension.
-v0.0.9  *pending*  - Checks positive and negative examples in test framework.
+v0.0.9  2019-04-22 - Checks positive and negative examples in test framework.
+                   - Adds ``RST212``, ``RST305`` and ``RST306`` (contribution
+                     from Brian Skinn).
 ======= ========== ===========================================================
 
 

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ RST207 Literal block ends without a blank line; unexpected unindent.
 RST208 Option list ends without a blank line; unexpected unindent.
 RST210 Inline strong start-string without end-string.
 RST211 Blank line required after table.
+RST212 Title underline too short.
 RST299 Previously unseen warning, not yet assigned a unique code.
 ====== =======================================================================
 
@@ -111,6 +112,8 @@ RST301 Unexpected indentation.
 RST302 Malformed table.
 RST303 Unknown directive type "XXX".
 RST304 Unknown interpreted text role "XXX".
+RST305 Undefined substitution referenced: "XXX".
+RST306 Unknown target name: "XXX".
 RST399 Previously unseen major error, not yet assigned a unique code.
 ====== =======================================================================
 

--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -170,6 +170,7 @@ code_mapping_warning = {
     # Other:
     "Inline strong start-string without end-string.": 10,
     "Blank line required after table.": 11,
+    "Title underline too short.": 12,
 }
 
 # Level 3 - error
@@ -180,6 +181,10 @@ code_mapping_error = {
     "Unknown directive type": 3,
     # e.g. Unknown interpreted text role "need".
     "Unknown interpreted text role": 4,
+    # e.g. Undefined substitution referenced: "dict".
+    "Undefined substitution referenced:": 5,
+    # e.g. Unknown target name: "license_txt".
+    "Unknown target name:": 6,
 }
 
 # Level 4 - severe

--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -139,7 +139,7 @@ except AttributeError:
 import restructuredtext_lint as rst_lint
 
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 
 log = logging.getLogger(__name__)

--- a/tests/RST212/short_underline.py
+++ b/tests/RST212/short_underline.py
@@ -1,0 +1,22 @@
+"""Print 'Hello world' to the terminal.
+
+Long
+=====
+An overly long underline (here one extra equals sign)
+is considered acceptable.
+
+Short
+====
+There is a missing equals sign on the above underline,
+and that is considered an error. This should fail::
+
+    $ flake8 --select RST RST212/short_underline.py
+    RST212/short_underline.py:10:1: RST299 Title underline too short.
+
+Nice
+====
+Finally, this underline is just right.
+
+"""
+
+print("Hello world")

--- a/tests/RST305/subsitution.py
+++ b/tests/RST305/subsitution.py
@@ -1,0 +1,19 @@
+"""Print 'Hello world' to the terminal.
+
+Here's where the |foo| substitution is used - it is defined
+below.
+
+.. |foo| replace:: Here's where it's defined.
+
+So far so good, but what if the definition is not in the same
+docstring fragment - it could be in an included footer?
+
+Here the |bar| substituion definition is missing, so this
+docstring in isolation should fail validation::
+
+    $ flake8 --select RST RST305/substitution.py
+    RST305/subsitution.py:12:1: RST305 Undefined substitution referenced: "bar"
+
+"""
+
+print("Hello world")

--- a/tests/RST306/unknown_target.py
+++ b/tests/RST306/unknown_target.py
@@ -1,0 +1,19 @@
+"""Print 'Hello world' to the terminal.
+
+Here's where the hyperlink-name_ is used, the target definition
+is next.
+
+.. _hyperlink-name: Here's where the hyperlink target is defined.
+
+So far so good, but what if the definition is not in the same
+docstring fragment - it could be in an included footer?
+
+Here a missing-link_ hyperlink is used, so this docstring in
+isolation should fail validation::
+
+    $ flake8 --select RST  RST306/unknown_target.py 
+    RST306/unknown_target.py:12:1: RST306 Unknown target name: "missing-link".
+
+"""
+
+print("Hello world")


### PR DESCRIPTION
Closes #9 and closes #10. Defines
 - `RST305`: Undefined substitution referenced: "XXX".
 - `RST306`: Unknown target name: "XXX".

Also defines a new 200-level code:
 - `RST212`: Title underline too short.

Updates `README.rst` to reflect these.