### PR TITLE
Implement a basic test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ script:
  - echo "On this machine \$LANG=$LANG"
  - echo "Checking our own docstrings are valid RST"
  - flake8 --select RST setup.py flake8_rst_docstrings.py
- - echo "Checking we can parse our valid test cases"
- - flake8 --select RST --ignore RST303,RST304 tests/test_cases/*.py
+ - cd tests/
+ - ./run_tests.sh
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,7 @@ v0.0.7  2017-08-25 - Remove triple-quotes before linting, was causing false
                      line at end of docstrings (bug fix for issue #1).
 v0.0.8  2017-10-09 - Adds ``RST303`` and ``RST304`` for unknown directives and
                      interpreted text role as used in Sphinx-Needs extension.
+v0.0.9  *pending*  - Checks positive and negative examples in test framework.
 ======= ========== ===========================================================
 
 

--- a/tests/RST303/sphinx-directives.py
+++ b/tests/RST303/sphinx-directives.py
@@ -1,6 +1,8 @@
 """Example reStructuredText from Sphinx-Needs project.
 
 From http://sphinxcontrib-needs.readthedocs.io/en/latest/
+but cut down and may not work in isolation. Intended just
+to trigger RST303.
 
 **Some data**
 
@@ -23,11 +25,6 @@ From http://sphinxcontrib-needs.readthedocs.io/en/latest/
    also a *status* is given.
 
 **Some text**
-
-Wohooo, we have created :need:`req_001`,
-which is linked by :need_incoming:`req_001`.
-
-**A filter**
 
 .. needfilter::
    :tags: example

--- a/tests/RST304/sphinx-roles.py
+++ b/tests/RST304/sphinx-roles.py
@@ -1,0 +1,14 @@
+"""Example reStructuredText from Sphinx-Needs project.
+
+From http://sphinxcontrib-needs.readthedocs.io/en/latest/
+but will not work in isolation - cut down just to trigger
+RST304.
+
+**Some text**
+
+Wohooo, we have created :need:`req_001`,
+which is linked by :need_incoming:`req_001`.
+
+"""
+
+print("sphinx-needs defines its own reStructuredText roles.")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+IFS=$'\n\t'
+set -eu
+# Note not using "set -o pipefile" until after check error message with grep
+
+# Examples which should fail
+for code in RST??? ; do
+    echo "======"
+    echo $code
+    echo "======"
+    flake8 --select RST $code/ 2>&1 | grep $code
+    echo "Return code $? from $code tests"
+done
+# echo "Positive tests passed (RST errors reported as expected)."
+
+set -o pipefail
+
+# Examples which should pass
+echo "========="
+echo "Negatives"
+echo "========="
+flake8 --select RST test_cases/
+#echo "Negative tests passed (no RST errors reported as expected)."
+
+echo "============"
+echo "Tests passed"
+echo "============"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,8 +8,11 @@ for code in RST??? ; do
     echo "======"
     echo $code
     echo "======"
-    flake8 --select RST $code/ 2>&1 | grep $code
-    echo "Return code $? from $code tests"
+    for file in $code/*.py ; do
+        echo "flake8 --select RST $file"
+        flake8 --select RST $file 2>&1 | grep $code
+    done
+    echo "Good, $code violations reported, as expected."
 done
 # echo "Positive tests passed (RST errors reported as expected)."
 
@@ -19,8 +22,9 @@ set -o pipefail
 echo "========="
 echo "Negatives"
 echo "========="
+echo "flake8 --select RST test_cases/"
 flake8 --select RST test_cases/
-#echo "Negative tests passed (no RST errors reported as expected)."
+echo "Good, no RST style violations reported, as expected."
 
 echo "============"
 echo "Tests passed"


### PR DESCRIPTION
Would address #3, although will need more work to add test cases for all the error codes defined to date.

Does not currently support test files intended to trigger multiple different RST codes at the same time (hopefully not an issue, could add special cases to the script as needed).

Sample output:

```
$ ./run_tests.sh
======
RST303
======
flake8 --select RST RST303/sphinx-directives.py
RST303/sphinx-directives.py:10:1: RST303 Unknown directive type "req".
RST303/sphinx-directives.py:17:1: RST303 Unknown directive type "spec".
RST303/sphinx-directives.py:30:1: RST303 Unknown directive type "needfilter".
Good, RST303 violations reported, as expected.
======
RST304
======
flake8 --select RST RST304/sphinx-roles.py
RST304/sphinx-roles.py:10:1: RST304 Unknown interpreted text role "need".
RST304/sphinx-roles.py:10:1: RST304 Unknown interpreted text role "need_incoming".
Good, RST304 violations reported, as expected.
=========
Negatives
=========
flake8 --select RST test_cases/
Good, no RST style violations reported, as expected.
============
Tests passed
============
```

If a test fails, the script stops with no output - that could be clearer but requires a more complicated bash script with if-statements etc. The current code is deliberately quite simple.