### PR TITLE
Add initial pytest suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ flake8_rst_docstrings.egg-info/
 
 #Ignore python build directories
 *__pycache__
+
+#Ignore any virtualenvs
+env*
+
+#Ignore coverage cache file
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ flake8_rst_docstrings.egg-info/
 
 #Ignore hidden files from Dolphin window manager
 .directory
+
+#Ignore python build directories
+*__pycache__

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [wheel]
 universal = 1
+
+[coverage:report]
+omit =
+    env*
+    setup.py
+    tests*

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,7 @@ setup(
     entry_points={
         "flake8.extension": ["RST = flake8_rst_docstrings:reStructuredTextChecker"]
     },
+    extras_require={
+        'test': ["pytest>=4.4.0", "pytest-cov", "pytest-subtests"],
+}
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,5 @@ setup(
     entry_points={
         "flake8.extension": ["RST = flake8_rst_docstrings:reStructuredTextChecker"]
     },
-    extras_require={
-        'test': ["pytest>=4.4.0", "pytest-cov", "pytest-subtests"],
-    }
+    extras_require={"test": ["pytest>=4.4.0", "pytest-cov", "pytest-subtests"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     },
     extras_require={
         'test': ["pytest>=4.4.0", "pytest-cov", "pytest-subtests"],
-}
+    }
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,9 +12,7 @@ tests_dir_path = Path(__file__).parent
 p_fail_dirname = re.compile(r"^RST(\d+)$", re.I)
 
 fail_dirs = [
-    d
-    for d in tests_dir_path.iterdir()
-    if d.is_dir() and p_fail_dirname.match(d.name)
+    d for d in tests_dir_path.iterdir() if d.is_dir() and p_fail_dirname.match(d.name)
 ]
 
 good_files = [
@@ -24,19 +22,14 @@ good_files = [
 ]
 
 
-@pytest.mark.parametrize('dir_path', fail_dirs, ids=(lambda d: d.name))
+@pytest.mark.parametrize("dir_path", fail_dirs, ids=(lambda d: d.name))
 def test_error_examples(dir_path, subtests):
     """Confirm expected-error docstrings."""
-    for file_path in [
-        f
-        for f in dir_path.iterdir()
-        if f.name.endswith(".py")
-    ]:
+    for file_path in [f for f in dir_path.iterdir() if f.name.endswith(".py")]:
         with subtests.test(msg=file_path.name):
             try:
                 sp.check_output(
-                    ["flake8", "--select", "RST", str(file_path.resolve())],
-                    shell=True,
+                    ["flake8", "--select", "RST", str(file_path.resolve())], shell=True
                 )
             except sp.CalledProcessError as e:
                 assert e.returncode == 1
@@ -45,7 +38,7 @@ def test_error_examples(dir_path, subtests):
                 pytest.fail("Error code {} not raised".format(dir_path.name))
 
 
-@pytest.mark.parametrize('file_path', good_files, ids=(lambda f: f.name))
+@pytest.mark.parametrize("file_path", good_files, ids=(lambda f: f.name))
 def test_good_examples(file_path):
     """Confirm expect-no-error docstrings."""
     assert 0 == sp.call(["flake8", "--select", "RST", str(file_path.resolve())])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,51 @@
+"""Core test module for flake8-rst-docstrings."""
+
+import re
+import subprocess as sp
+from pathlib import Path
+
+import pytest
+
+
+tests_dir_path = Path(__file__).parent
+
+p_fail_dirname = re.compile(r"^RST(\d+)$", re.I)
+
+fail_dirs = [
+    d
+    for d in tests_dir_path.iterdir()
+    if d.is_dir() and p_fail_dirname.match(d.name)
+]
+
+good_files = [
+    f
+    for f in (tests_dir_path / "test_cases").iterdir()
+    if f.is_file() and f.name.endswith(".py")
+]
+
+
+@pytest.mark.parametrize('dir_path', fail_dirs, ids=(lambda d: d.name))
+def test_error_examples(dir_path, subtests):
+    """Confirm expected-error docstrings."""
+    for file_path in [
+        f
+        for f in dir_path.iterdir()
+        if f.name.endswith(".py")
+    ]:
+        with subtests.test(msg=file_path.name):
+            try:
+                sp.check_output(
+                    ["flake8", "--select", "RST", str(file_path.resolve())],
+                    shell=True,
+                )
+            except sp.CalledProcessError as e:
+                assert e.returncode == 1
+                assert dir_path.name in e.output.decode()
+            else:
+                pytest.fail("Error code {} not raised".format(dir_path.name))
+
+
+@pytest.mark.parametrize('file_path', good_files, ids=(lambda f: f.name))
+def test_good_examples(file_path):
+    """Confirm expect-no-error docstrings."""
+    assert 0 == sp.call(["flake8", "--select", "RST", str(file_path.resolve())])


### PR DESCRIPTION
I put `pytest` and a couple of plugins into the "test" subset of `extras_require` in `setup.py`. In order to get them installed, you currently have to:

```
$ pip install -e .[test]
```

Could easily relocate this to `requirements.txt` or wherever, if you'd like them installed every time.

In any event, to run the new suite just:

```
$ pytest
```

If you want coverage, run:

```
$ pytest --cov=.
```

I **think** switching Travis to use this should be as simple as adding the pytest & plugin requirements to [`before_install`](https://github.com/peterjc/flake8-rst-docstrings/blob/4803527f84a66e854096911a6c546a1bed927d80/.travis.yml#L23) and replacing [these two lines](https://github.com/peterjc/flake8-rst-docstrings/blob/4803527f84a66e854096911a6c546a1bed927d80/.travis.yml#L37-L38) with `- pytest`

-----

No explicit pytest config was added, and no root `conftest.py` created; neither may be needed if test suite stays simple.

New expected-error tests can be added by creating new `.py` files in the relevant `RST###` directory; add a missing `RST###` directory if needed and it will be identified automatically. This should be fully consistent with the prior shellscript suite.

Add any additional expected-good test files in `tests/test_cases`. Might be worth renaming this directory to something like `good_tests`?


I also added `__pycache__` directories and some other things to `.gitignore`.


Of course, please feel free to add/remove/change anything at all, or just decline the PR if you don't want to mess with it.