### PR TITLE
Avoid flake8 warning: Remove unused builtins parameter in initializer

### DIFF
--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -965,7 +965,7 @@ class reStructuredTextChecker(object):
 
     STDIN_NAMES = set(["stdin", "-", "(none)", None])
 
-    def __init__(self, tree, filename="(none)", builtins=None):
+    def __init__(self, tree, filename="(none)"):
         """Initialise."""
         self.tree = tree
         self.filename = filename


### PR DESCRIPTION
`builtins` is an unsupported parameter, see https://github.com/PyCQA/flake8/commit/2d3e277b1e0c0a24c30c611558692f95d14a8470, https://gitlab.com/pycqa/flake8-docstrings/merge_requests/8
Causes unnecessary warnings, e.g.
```
WARNING  flake8.processor:processor.py:248 Plugin requested optional parameter "builtins" but this is not an available parameter.
```
Since it's not used anyway, there's no harm in removing it.