### PR TITLE
Configurable extra RST directives and roles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,12 +177,44 @@ Note in addition to the ``RST`` prefix alone you can use partial codes
 like ``RST2`` meaning ``RST200``, ``RST201``, ... and so on.
 
 
+Configuration
+-------------
+
+We assume you are familiar with `flake8 configuration
+<http://flake8.pycqa.org/en/latest/user/configuration.html>`_.
+
+If you are using Sphinx or other extensions to reStructuredText, you will
+want to define any additional directives or roles you are using to avoid
+false positive ``RST303`` and ``RST304`` violations.
+
+You can set these at the command line if you wish::
+
+    $ flake8 --rst-roles class,func,ref --rst-directives envvar,exception ...
+
+We recommend using the following settings in your ``flake8`` configuration,
+for example in your ``.flake8``, ``setup.cfg``, or ``tox.ini`` file, e.g.::
+
+    [flake8]
+    rst-roles =
+        class,
+        func,
+        ref,
+    rst-directives =
+        envvar,
+        exception,
+
+Note that flake8 allows splitting the comma separated lists over multiple
+lines, and allows including of hash comment lines.
+
+
 Version History
 ---------------
 
 ======= ========== ===========================================================
 Version Released   Changes
 ------- ---------- -----------------------------------------------------------
+v0.0.11 2019-08-7  - Configuration options to define additional directives and
+                     roles (e.g. from Sphinx) for ``RST303`` and ``RST304``.
 v0.0.10 2019-06-17 - Fixed flake8 "builtins" parameter warning (contribution
                      from `Ruben, @ROpdebee <https://github.com/ROpdebee>`_).
 v0.0.9  2019-04-22 - Checks positive and negative examples in test framework.

--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -139,7 +139,7 @@ except AttributeError:
 import restructuredtext_lint as rst_lint
 
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 
 log = logging.getLogger(__name__)

--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -976,6 +976,32 @@ class reStructuredTextChecker(object):
             self.source = None
             self.err = err
 
+    @classmethod
+    def add_options(cls, parser):
+        """Add RST directives and roles options."""
+        parser.add_option(
+            "--rst-directives",
+            metavar="LIST",
+            default="",
+            parse_from_config=True,
+            comma_separated_list=True,
+            help="Comma-separated list of additional RST directives.",
+        )
+        parser.add_option(
+            "--rst-roles",
+            metavar="LIST",
+            default="",
+            parse_from_config=True,
+            comma_separated_list=True,
+            help="Comma-separated list of additional RST roles.",
+        )
+
+    @classmethod
+    def parse_options(cls, options):
+        """Adding black-config option."""
+        cls.extra_directives = options.rst_directives
+        cls.extra_roles = options.rst_roles
+
     def run(self):
         """Use docutils to check docstrings are valid RST."""
         # Is there any reason not to call load_source here?

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,6 +26,12 @@ echo "flake8 --select RST test_cases/"
 flake8 --select RST test_cases/
 echo "Good, no RST style violations reported, as expected."
 
+echo "========="
+echo "Help text"
+echo "========="
+flake8 -h | grep -i RST
+echo "Good, RST options appear in the help text"
+
 echo "============"
 echo "Tests passed"
 echo "============"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,6 +26,20 @@ echo "flake8 --select RST test_cases/"
 flake8 --select RST test_cases/
 echo "Good, no RST style violations reported, as expected."
 
+echo "================"
+echo "Extra directives"
+echo "================"
+# Checked this failed earlier in the RST303 tests
+flake8 --select RST --rst-directives=req,spec,needfilter RST303/sphinx-directives.py
+echo "Good, no RST303 style violations reported, as expected."
+
+echo "==========="
+echo "Extra roles"
+echo "==========="
+# Checked this failed earlier in the RST304 tests
+flake8 --select RST --rst-roles need,need_incoming RST304/sphinx-roles.py
+echo "Good, no RST304 style violations reported, as expected."
+
 echo "========="
 echo "Help text"
 echo "========="


### PR DESCRIPTION
This should close #7.

Example tested on a large code base - the following worked on the numpy master branch (they use Sphinx with their own numpydocs extension):

```
$ flake8 --select RST303,RST304 --rst-directives autosummary,data,currentmodule,deprecated,glossary,moduleauthor,plot,testcode,versionadded,versionchanged --rst-roles attr,class,func,meth,mod,obj,ref,term,c:member,py:func,py:mod numpy/
```

i.e. If they were using flake8, they could put this in their config file:

```
[flake8]
rst-directives =
    # These are sorted alphabetically - but that does not matter
    autosummary,data,currentmodule,deprecated,
    glossary,moduleauthor,plot,testcode,
    versionadded,versionchanged,
rst-roles =
    attr,class,func,meth,mod,obj,ref,term,
    # C programming language:
    c:member,
    # Python programming language:
    py:func,py:mod,
```