### PR TITLE
Hack to special case *args and *kwargs in args/parameter lists

### DIFF
--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -1090,6 +1090,28 @@ class reStructuredTextChecker(object):
                 assert 0 < code < 100, code
                 code += 100 * rst_error.level
                 msg = "%s%03i %s" % (rst_prefix, code, msg)
+                if code == 213:
+                    if "\nArgs:\n" in unindented and unindented.find(
+                        "\nArgs:\n"
+                    ) < unindented.find("    *args:"):
+                        # Ignore special case used in Google docstring style
+                        continue
+                    if "\nParameters\n----------\n" in unindented and unindented.find(
+                        "\nParameters\n----------\n"
+                    ) < unindented.find("\n*args\n"):
+                        # Ignore special case used in NumPy docstring style
+                        continue
+                if code == 210:
+                    if "\nArgs:\n" in unindented and unindented.find(
+                        "\nArgs:\n"
+                    ) < unindented.find("    **kwargs:"):
+                        # Ignore special case used in Google docstring style
+                        continue
+                    if "\nParameters\n----------\n" in unindented and unindented.find(
+                        "\nParameters\n----------\n"
+                    ) < unindented.find("\n**kwargs\n"):
+                        # Ignore special case used in NumPy docstring style
+                        continue
 
                 # This will return the line number by combining the
                 # start of the docstring with the offet within it.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -29,14 +29,14 @@ echo "Good, no RST style violations reported, as expected."
 echo "================"
 echo "Extra directives"
 echo "================"
-# Checked this failed earlier in the RST303 tests
+# Checked this failed by default in the RST303 tests
 flake8 --select RST --rst-directives=req,spec,needfilter RST303/sphinx-directives.py
 echo "Good, no RST303 style violations reported, as expected."
 
 echo "==========="
 echo "Extra roles"
 echo "==========="
-# Checked this failed earlier in the RST304 tests
+# Checked this failed by default in the RST304 tests
 flake8 --select RST --rst-roles need,need_incoming RST304/sphinx-roles.py
 echo "Good, no RST304 style violations reported, as expected."
 

--- a/tests/test_cases/google_args_and_kwargs.py
+++ b/tests/test_cases/google_args_and_kwargs.py
@@ -1,0 +1,15 @@
+def module_level_function(param1, param2=None, *args, **kwargs):
+    """This is an example of a module level function.
+
+    Here using the Google docstring style, notice that we have *not* escaped
+    the asterisk in ``*args*`` or ``**kwargs`` in the argument list.
+
+    Args:
+        param1 (int): The first parameter.
+        param2 (str, optional): The second parameter. Defaults to None.
+        *args: Variable length argument list.
+        **kwargs: Arbitrary keyword arguments.
+
+    ...
+    """
+    pass

--- a/tests/test_cases/numpy_args_and_kwargs.py
+++ b/tests/test_cases/numpy_args_and_kwargs.py
@@ -1,0 +1,20 @@
+def module_level_function(param1, param2=None, *args, **kwargs):
+    """This is an example of a module level function.
+
+    Here using the Numpy docstring style, notice that we have *not* escaped
+    the asterisk in ``*args*`` or ``**kwargs`` in the parameter list.
+
+    Parameters
+    ----------
+    param1 : int
+        The first parameter.
+    param2 : str optional
+        The second parameter.
+    *args
+        Variable length argument list.
+    **kwargs
+        Arbitrary keyword arguments.
+
+    ...
+    """
+    pass


### PR DESCRIPTION
This might solve #18, but at the cost of hiding some true misuse of italics or bold within the same docstring. Might be worthwhile all the same?

(This is a bit of a surface level hack - A more precise fix would need deeper integration into the docutils internals)