### PR TITLE
Ensure `bdist_wheel` doesn't produce universal whl

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [wheel]
-universal = 1
+universal = 0


### PR DESCRIPTION
`universal=1` causes the resulting wheel to be tagged as `py2.py3` which is wrong.
Going forward, only `py3` tagged wheels should be produced in non-py2 codebase.