### PR TITLE
Fix line numbers under Python 3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,8 @@ Version History
 ======= ========== ===========================================================
 Version Released   Changes
 ------- ---------- -----------------------------------------------------------
+v0.2.2  2021-04-30 - Fixed line number problem under Python 3.8 or later.
+                   - Corrected off-by-one line number in module docstrings.
 v0.2.1  2021-04-23 - Minor internal style change.
 v0.2.0  2021-04-23 - Use AST from flake8, not re-parsing with pydocstyle.
                    - Drops ``RST901`` (internal problem with parser).

--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -9,7 +9,7 @@ import ast
 import restructuredtext_lint as rst_lint
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 rst_prefix = "RST"

--- a/tests/RST202/bullets.py
+++ b/tests/RST202/bullets.py
@@ -9,7 +9,7 @@ Other fruit.
 It should therefore fail RST validation::
 
     $ flake8 --select RST RST202/bullets.py
-    RST202/bullets.py:8:1: RST202 Bullet list ends without a blank line; unexpected unindent.
+    RST202/bullets.py:7:1: RST202 Bullet list ends without a blank line; unexpected unindent.
     RST202/bullets.py:38:1: RST202 Bullet list ends without a blank line; unexpected unindent.
 
 The end.

--- a/tests/RST206/field_lists.py
+++ b/tests/RST206/field_lists.py
@@ -21,7 +21,7 @@ Because the line above is not indented or separated from
 the field list by a blank line, it is not valid RST:
 
     $ flake8 --select RST RST206/fields_list.py
-    RST206/field_lists.py:19:1: RST206 Field list ends without a blank line; unexpected unindent.
+    RST206/field_lists.py:18:1: RST206 Field list ends without a blank line; unexpected unindent.
 
 The end.
 """  # noqa: E501

--- a/tests/RST208/option_list.py
+++ b/tests/RST208/option_list.py
@@ -29,7 +29,7 @@ There ought to be a blank line before that final comment,
 there isn't so this fails validation:
 
     $ flake8 --select RST RST208/option_list.py
-    RST208/option_list.py:27:1: RST208 Option list ends without a blank line; unexpected unindent.
+    RST208/option_list.py:26:1: RST208 Option list ends without a blank line; unexpected unindent.
 
 The end.
 """  # noqa: E501

--- a/tests/RST210/strong.py
+++ b/tests/RST210/strong.py
@@ -8,7 +8,7 @@ Here **strong is missing a closing double asterisk.
 That is considered to be an error, and should fail::
 
     $ flake8 --select RST RST210/strong.py
-    RST210/strong.py:7:1: RST210 Inline strong start-string without end-string.
+    RST210/strong.py:6:1: RST210 Inline strong start-string without end-string.
 
 """
 

--- a/tests/RST212/short_underline.py
+++ b/tests/RST212/short_underline.py
@@ -11,7 +11,7 @@ There is a missing equals sign on the above underline,
 and that is considered an error. This should fail::
 
     $ flake8 --select RST RST212/short_underline.py
-    RST212/short_underline.py:10:1: RST212 Title underline too short.
+    RST212/short_underline.py:9:1: RST212 Title underline too short.
 
 Nice
 ====

--- a/tests/RST213/emphasis.py
+++ b/tests/RST213/emphasis.py
@@ -8,7 +8,7 @@ Here *emphasis is missing a closing asterisk.
 That is considered to be an error, and should fail::
 
     $ flake8 --select RST RST213/emphasis.py
-    RST213/emphasis.py:7:1: RST213 Inline emphasis start-string without end-string.
+    RST213/emphasis.py:6:1: RST213 Inline emphasis start-string without end-string.
 
 """
 

--- a/tests/RST214/literal.py
+++ b/tests/RST214/literal.py
@@ -8,7 +8,7 @@ Here ``literal is missing the closing backticks.
 That is considered to be an error, and should fail::
 
     $ flake8 --select RST RST214/literal.py
-    RST214/literal.py:7:1: RST214 Inline emphasis start-string without end-string.
+    RST214/literal.py:6:1: RST214 Inline emphasis start-string without end-string.
 
 """
 

--- a/tests/RST215/backticks.py
+++ b/tests/RST215/backticks.py
@@ -8,7 +8,7 @@ Here `example is missing a closing backtick.
 That is considered to be an error, and should fail::
 
     $ flake8 --select RST RST215/backticks.py
-    RST215/backticks.py:7:1: RST215 Inline interpreted text or phrase reference start-string without end-string.
+    RST215/backticks.py:6:1: RST215 Inline interpreted text or phrase reference start-string without end-string.
 
 """  # noqa: E501
 

--- a/tests/RST217/roles.py
+++ b/tests/RST217/roles.py
@@ -10,7 +10,7 @@ However, trailing underscores have special meaning for referencing, thus
 `code`:example:_ is considered to be an error:
 
     $ flake8 --select RST RST217/roles.py
-    RST217/roles.py:10:1: RST17 Mismatch: both interpreted text role suffix and reference suffix.
+    RST217/roles.py:9:1: RST17 Mismatch: both interpreted text role suffix and reference suffix.
 
 """  # noqa: E501
 

--- a/tests/RST218/no_literal_block.py
+++ b/tests/RST218/no_literal_block.py
@@ -5,7 +5,7 @@ indented text is a literal block. The following
 code snippet is a typical usage::
 
     $ flake8 --select RST RST218/no_literal_block.py
-    RST218/no_literal_block.py:14:1: RST218 Literal block expected; none found.
+    RST218/no_literal_block.py:13:1: RST218 Literal block expected; none found.
 
 This file triggers an error because this paragraph
 says there should be a following literal block, but

--- a/tests/RST305/subsitution.py
+++ b/tests/RST305/subsitution.py
@@ -12,7 +12,7 @@ Here the |bar| substituion definition is missing, so this
 docstring in isolation should fail validation::
 
     $ flake8 --select RST RST305/substitution.py
-    RST305/subsitution.py:12:1: RST305 Undefined substitution referenced: "bar"
+    RST305/subsitution.py:11:1: RST305 Undefined substitution referenced: "bar"
 
 """
 

--- a/tests/RST306/unknown_target.py
+++ b/tests/RST306/unknown_target.py
@@ -12,7 +12,7 @@ Here a missing-link_ hyperlink is used, so this docstring in
 isolation should fail validation::
 
     $ flake8 --select RST  RST306/unknown_target.py
-    RST306/unknown_target.py:12:1: RST306 Unknown target name: "missing-link".
+    RST306/unknown_target.py:11:1: RST306 Unknown target name: "missing-link".
 
 """
 

--- a/tests/RST307/code_invalid_arg.py
+++ b/tests/RST307/code_invalid_arg.py
@@ -35,9 +35,9 @@ And:
 Sadly docutils considers all three examples to be invalid:
 
     $ flake8 --select RST  RST307/code_invalid_arg.py
-    RST307/code_invalid_arg.py:14:1: RST307 Error in "code" directive
-    RST307/code_invalid_arg.py:23:1: RST307 Error in "code-block" directive:
-    RST307/code_invalid_arg.py:31:1: RST307 Error in "code-block" directive:
+    RST307/code_invalid_arg.py:13:1: RST307 Error in "code" directive
+    RST307/code_invalid_arg.py:22:1: RST307 Error in "code-block" directive:
+    RST307/code_invalid_arg.py:30:1: RST307 Error in "code-block" directive:
 
 """
 


### PR DESCRIPTION
Fixes #36 (line numbers under Python 3.8 where the AST changed), and a historical off-by-one with module level docstrings (the root cause of which escapes me but will go away as we drop the older Python versions).