### PR TITLE
Port over Travis to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,35 @@ on:
     branches: [ master ]
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Lint code
+      run: |
+        if grep -P '\t' *.py *.rst; then
+            echo 'Tabs are bad, please use four spaces.';
+            false;
+        fi
+        if grep -n -r '[[:blank:]]$' *.py *.rst; then
+            echo 'Please remove trailing whitespace.'; false;
+        fi
+        pip install --upgrade pip setuptools
+        pip install flake8 flake8-docstrings restructuredtext-lint flake8-black;
+        echo "Using restructuredtext-lint to check documentation"
+        restructuredtext-lint *.rst
+        echo "Using flake8 to check Python code"
+        flake8 setup.py flake8_rst_docstrings.py
+
   run-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include: 
+        include:
           - python-version: 3.4
           - python-version: 3.5
           - python-version: 3.6
@@ -24,24 +48,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        if grep '\t' *.py *.rst; then
-            echo 'Tabs are bad, please use four spaces.';
-            false;
-        fi
-        if grep -n -r '[[:blank:]]$' *.py *.rst; then
-            echo 'Please remove trailing whitespace.'; false;
-        fi
-        pip install --upgrade pip setuptools
-        pip install flake8 flake8-docstrings restructuredtext-lint
-        if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then
-            pip install flake8-black;
-        fi
-        echo "Using restructuredtext-lint to check documentation"
-        restructuredtext-lint *.rst
-        echo "Using flake8 to check Python code"
-        flake8 setup.py flake8_rst_docstrings.py
     - name: Install package
       run: |
         python setup.py install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: 
+          - python-version: 3.4
+          - python-version: 3.5
+          - python-version: 3.6
+          - python-version: 3.7
+          - python-version: 3.8
+          - python-version: 3.9
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        if grep '\t' *.py *.rst; then
+            echo 'Tabs are bad, please use four spaces.';
+            false;
+        fi
+        if grep -n -r '[[:blank:]]$' *.py *.rst; then
+            echo 'Please remove trailing whitespace.'; false;
+        fi
+        pip install --upgrade pip setuptools
+        pip install flake8 flake8-docstrings restructuredtext-lint
+        if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then
+            pip install flake8-black;
+        fi
+        echo "Using restructuredtext-lint to check documentation"
+        restructuredtext-lint *.rst
+        echo "Using flake8 to check Python code"
+        flake8 setup.py flake8_rst_docstrings.py
+    - name: Install package
+      run: |
+        python setup.py install
+    - name: Run tests
+      run: |
+        echo "On this machine \$LANG=$LANG"
+        echo "Checking our own docstrings are valid RST"
+        flake8 --select RST setup.py flake8_rst_docstrings.py
+        cd tests/
+        ./run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.5
           - python-version: 3.6
           - python-version: 3.7
           - python-version: 3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: test
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   linting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - python-version: 3.4
           - python-version: 3.5
           - python-version: 3.6
           - python-version: 3.7


### PR DESCRIPTION
Hey, thanks for the awesome project! This is my attempt at porting over the Travis-CI tests to GitHub Actions. I know you mentioned CircleCI in #40 but I think GitHub Actions might be easier to use/maintain in the long run. The only changes compared to the `travis.yml` script are:
- changed Python test matrix to 3.6-3.9, since I had trouble installing Python/dependencies for 3.4 and 3.5. Given that both of those are EOL, I think this is probably okay.
- I split out the linting into a separate job for additional parallelization

Things that could be done:
- add a badge to README
- deprecate Travis jobs?
- automate PyPI releases (this might take some time to set up correctly)

Any feedback is welcome :)