### PR TITLE
Ignore signature overrides

### DIFF
--- a/tests/RST203/def_list.py
+++ b/tests/RST203/def_list.py
@@ -3,15 +3,17 @@
 This is expected to fail validation:
 
     $ flake8 --select RST RST203/def_list.py
-    RST203/def_list.py:21:1: RST203 Definition list ends without a blank line; unexpected unindent.
+    RST203/def_list.py:23:1: RST203 Definition list ends without a blank line; unexpected unindent.
 
 In this case, the four parameters should all have their own ``:parameter``
 opening.
 """  # noqa: E501
 
 
-def box(x1, y1, width=500, height=100):
-    """Draw a box.
+def box(*args, **kwargs):
+    """box(x1, y1, width, height) -> Graphics
+
+    Draw a box.
 
     :parameter
         x1: - required left coordinate, float
@@ -19,5 +21,5 @@ def box(x1, y1, width=500, height=100):
         width: - optional width, float
         height: - optional height, float
     :return: Graphics object
-    """
+    """  # noqa: D400, D402
     pass

--- a/tests/test_cases/explicit_signature.py
+++ b/tests/test_cases/explicit_signature.py
@@ -1,0 +1,33 @@
+"""This files uses signature overloading / overriding.
+
+When Python can not express a signature, it is permissible to use the
+first line of the docstring as a signature, this is extracted by
+e.g. sphinx.
+
+Examples from the standard library:
+https://github.com/python/cpython/blob/3.10/Lib/textwrap.py#L350
+
+"""
+
+
+def legacy_positional(*args, **kwargs):
+    """legacy_positional([thing][, **things])
+
+    Can be confused with RST210 (inline strong without end).
+
+    Before Python 3.8 (PEP 570), pure python did not have
+    positional-only arguments (to say nothing of optional ones), they
+    had to be emulated via `*args` and signature overrides allowed
+    properly documenting them regardless.
+    """  # noqa: D400, D402
+
+
+# fmt: off
+def forwarding(*args):
+    """ forwarding(x, *y)
+
+    Can be confused with RST213 (inline emphasis without end).
+
+    An other common use case is forwarding args directly but wanting
+    to properly document *some* still.
+    """  # noqa: D210, D400, D402


### PR DESCRIPTION
Fixes #46

I included 2 versions of the fix (as well as a minor improvement to the test harness, which incidentally is fairly uncomfortable to run).

Version one is what was discussed in #46, using sphinx's regex as-is, however because the sphinx regex is (apparently) designed to run on trimmed split lines it felt a bit meh, as it requires splitting out the first line, checking the match (on the trimmed first line), then doing the replacement.

The second version uses a modified (and slightly more complicated) version of the Sphinx regex -- I don't think it's a big issue as the regex apparently has not been modified once since it was introduced in 2008 (in sphinx 0.6) -- so it can just do the replacement unconditionally via `re`, no faffing about with conditionals or anything.