### PR TITLE
fix incorrect line offsets under Python <= 3.7

### DIFF
--- a/flake8_rst_docstrings.py
+++ b/flake8_rst_docstrings.py
@@ -180,11 +180,11 @@ class reStructuredTextChecker:
                         start = node.body[0].lineno - 1  # AST value 1 based
                     except AttributeError:
                         # On Python 3.7 or older, and must compute start line
-                        start = node.body[0].lineno - len(
-                            ast.get_docstring(node, clean=False).splitlines()
+                        start = (
+                            node.body[0].lineno
+                            - ast.get_docstring(node, clean=False).count("\n")
+                            - 1
                         )
-                        if isinstance(node, ast.Module) and start > 1:
-                            start -= 1  # Why?
                     assert (
                         node.body[0].lineno >= 1 and start >= 0
                     ), "Bad start line, node line number %i for: %s\n" % (


### PR DESCRIPTION
As noted on #49, there was still a difference in behaviour on older versions of Python.

Python 3.8:

```console
$ flake8 --select RST RST216/roles.py
RST216/roles.py:9:1: RST216 Multiple roles in interpreted text (both prefix and suffix present; only one allowed).
```

On Python 3.7 (before this fix) got the line number wrong:

```console
$ flake8 --select RST RST216/roles.py
RST216/roles.py:10:1: RST216 Multiple roles in interpreted text (both prefix and suffix present; only one allowed).
```

Problem dates from #37 (not reliably counting the number of lines in a docstring), with #38 only a partial fix.

Fix by @xmo-odoo cherry-picked from #51, black style applied, and git commit comment re-written.