### PR TITLE
Test cases for `int`s and ``int``s

### DIFF
--- a/tests/RST214/plurals.py
+++ b/tests/RST214/plurals.py
@@ -1,0 +1,19 @@
+"""Print 'Hello world' to the terminal.
+
+RST uses double backticks for ``literals`` like code
+snippets. Surprisingly ``literal``s is not valid,
+something you might see in examples like ``int``s
+talking about plurals of a datatype.
+
+That is considered to be an error, and should fail::
+
+    $ flake8 --select RST RST214/plurals.py
+    RST214/plurals.py:3:1: RST214 Inline literal start-string without end-string.
+    RST214/plurals.py:3:1: RST214 Inline literal start-string without end-string.
+
+Note the line number is unfortunately given as the
+start of the paragraph. The same happens with single
+backticks, see RST215.
+"""
+
+print("Hello world")

--- a/tests/RST215/plurals.py
+++ b/tests/RST215/plurals.py
@@ -1,0 +1,18 @@
+"""Print 'Hello world' to the terminal.
+
+RST uses single backticks for inline `interpreted text`,
+and like inline literals with double backticks, this is
+often used for code snippets. Surprisingly trying to
+write plurals like `int`s is not valid RST.
+
+That is considered to be an error, and should fail::
+
+    $ flake8 --select RST RST215/plurals.py
+    RST215/plurals.py:3:1: RST215 Inline interpreted text or phrase reference start-string without end-string.
+
+Note the line number is unfortunately given as the start
+of the paragraph. The same happens with double backticks
+for in-line literals, see RST214.
+"""  # noqa: E501
+
+print("Hello world")


### PR DESCRIPTION
This would close issue #67 with some test cases.

Note the line number limitation, you get the start of the paragraph.